### PR TITLE
Fix text overflow on 'customize this page' buttons.

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -389,10 +389,9 @@ body.arts .page-navbkg .singlebutton button:hover {
 
 @include media-breakpoint-down(sm) {
     .page-navbkg .singlebutton button {
-		width: 1.75em;
 	    overflow: hidden;
-	    font-size: 1.5em;
-	    padding: 0 0.35em;
+	    font-size: .9375rem;
+        padding: .375rem .75rem;
     }
 	.page-navbkg .singlebutton button:before {
 	    padding-right: 1em;


### PR DESCRIPTION
Fix text overflow on dashboard's 'Customize This Page' button.

**Before**
![before](https://user-images.githubusercontent.com/46030891/87060438-c2dae700-c1c7-11ea-8d61-d156a43487c0.png)

**After**
![after](https://user-images.githubusercontent.com/46030891/87060448-c8383180-c1c7-11ea-9519-2ba2d94dbf4e.png)
![after2](https://user-images.githubusercontent.com/46030891/87060451-c9695e80-c1c7-11ea-8810-e43a10327b16.png)

